### PR TITLE
Add SignatureWindow back into Spectral CMake build.

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -359,6 +359,7 @@ set(SPECTRAL_PLUGINS # all subfolders that contain a ModuleManager.cpp or module
     Resampler
     Sam
     Signature
+    SignatureWindow
     SpectralLibrary
     SpectralLibraryMatch
     )

--- a/Code/Include/SpectralVersion.h
+++ b/Code/Include/SpectralVersion.h
@@ -1,6 +1,6 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
@@ -12,7 +12,7 @@
 
 #define SPECTRAL_NAME "Spectral processing algorithms"
 #define SPECTRAL_NAME_LONG "Algorithms to perform hyper and multi-spectral analysis"
-#define SPECTRAL_COPYRIGHT "Copyright © 2010, Ball Aerospace & Technologies Corp."
+#define SPECTRAL_COPYRIGHT "Copyright(c) 2021, Ball Aerospace & Technologies Corp."
 #define SPECTRAL_VERSION_NUMBER "1.9.0rc1"
 #define SPECTRAL_IS_PRODUCTION_RELEASE false
 

--- a/Code/SignatureWindow/CMakeLists.txt
+++ b/Code/SignatureWindow/CMakeLists.txt
@@ -11,7 +11,6 @@ set (SOURCE_FILES
    PropertiesSignaturePlotObject.cpp
    SignaturePlotObject.cpp
    SignatureWindow.cpp
-   SignatureWindowIcons.cpp
    SignatureWindowOptions.cpp
    )
 

--- a/Code/SignatureWindow/PropertiesSignaturePlotObject.cpp
+++ b/Code/SignatureWindow/PropertiesSignaturePlotObject.cpp
@@ -1,13 +1,13 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
  * http://www.gnu.org/licenses/lgpl.html
  */
 
-#include <QtGui/QLayout>
+#include <QtWidgets/QLayout>
 
 #include "CustomColorButton.h"
 #include "LabeledSection.h"

--- a/Code/SignatureWindow/PropertiesSignaturePlotObject.h
+++ b/Code/SignatureWindow/PropertiesSignaturePlotObject.h
@@ -1,6 +1,6 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
@@ -10,9 +10,9 @@
 #ifndef PROPERTIESSIGNATUREPLOTOBJECT_H
 #define PROPERTIESSIGNATUREPLOTOBJECT_H
 
-#include <QtGui/QCheckBox>
-#include <QtGui/QLabel>
-#include <QtGui/QSpinBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QSpinBox>
 
 #include "LabeledSectionGroup.h"
 

--- a/Code/SignatureWindow/SignaturePlotObject.cpp
+++ b/Code/SignatureWindow/SignaturePlotObject.cpp
@@ -1,6 +1,6 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
@@ -8,10 +8,10 @@
  */
 
 #include <QtGui/QBitmap>
-#include <QtGui/QColorDialog>
-#include <QtGui/QInputDialog>
-#include <QtGui/QMenu>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QColorDialog>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtGui/QMouseEvent>
 
 #include "AppAssert.h"
@@ -198,8 +198,7 @@ SignaturePlotObject::SignaturePlotObject(PlotWidget* pPlotWidget, Progress* pPro
 
    // Plot
    QPixmap pixOpenSig(SignatureWindowIcons::OpenSignatureIcon);
-   QBitmap bmpOpenSig(SignatureWindowIcons::OpenSignatureMask);
-   pixOpenSig.setMask(bmpOpenSig);
+   pixOpenSig.setMask(QPixmap(SignatureWindowIcons::OpenSignatureMask));
 
    mpAddSignatureAction = new QAction(QIcon(pixOpenSig), "Add Signature...", pParent);
    mpAddSignatureAction->setAutoRepeat(false);
@@ -211,8 +210,7 @@ SignaturePlotObject::SignaturePlotObject(PlotWidget* pPlotWidget, Progress* pPro
    pWidget->addAction(mpAddSignatureAction);
 
    QPixmap pixSaveSig(SignatureWindowIcons::SaveSignatureIcon);
-   QBitmap bmpSaveSig(SignatureWindowIcons::SaveSignatureMask);
-   pixSaveSig.setMask(bmpSaveSig);
+   pixSaveSig.setMask(QPixmap(SignatureWindowIcons::SaveSignatureMask));
 
    mpSaveSignatureAction = new QAction(QIcon(pixSaveSig), "Save Signatures...", pParent);
    mpSaveSignatureAction->setAutoRepeat(false);

--- a/Code/SignatureWindow/SignaturePlotObject.h
+++ b/Code/SignatureWindow/SignaturePlotObject.h
@@ -1,6 +1,6 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
@@ -12,7 +12,7 @@
 
 #include <QtCore/QMap>
 #include <QtCore/QObject>
-#include <QtGui/QAction>
+#include <QtWidgets/QAction>
 
 #include "AttachmentPtr.h"
 #include "ColorType.h"

--- a/Code/SignatureWindow/SignatureWindow.cpp
+++ b/Code/SignatureWindow/SignatureWindow.cpp
@@ -1,13 +1,13 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
  * http://www.gnu.org/licenses/lgpl.html
  */
 
-#include <QtGui/QAction>
+#include <QtWidgets/QAction>
 #include <QtGui/QBitmap>
 #include <QtGui/QMouseEvent>
 
@@ -242,8 +242,7 @@ bool SignatureWindow::execute(PlugInArgList* pInArgList, PlugInArgList* pOutArgL
 
       // Create the pixel spectrum action
       QPixmap pixPixelSignature(SignatureWindowIcons::PixelSignatureIcon);
-      QBitmap bmpPixelSignatureMask(SignatureWindowIcons::PixelSignatureMask);
-      pixPixelSignature.setMask(bmpPixelSignatureMask);
+      pixPixelSignature.setMask(QPixmap(SignatureWindowIcons::PixelSignatureMask));
 
       mpPixelSignatureAction = new QAction(QIcon(pixPixelSignature), "&Display Pixel Signature", this);
       mpPixelSignatureAction->setAutoRepeat(false);
@@ -252,8 +251,7 @@ bool SignatureWindow::execute(PlugInArgList* pInArgList, PlugInArgList* pOutArgL
 
       // Create the AOI signatures action
       QPixmap pixAoiSignatures(SignatureWindowIcons::AoiSignatureIcon);
-      QBitmap bmpAoiSignaturesMask(SignatureWindowIcons::AoiSignatureMask);
-      pixAoiSignatures.setMask(bmpAoiSignaturesMask);
+      pixAoiSignatures.setMask(QPixmap(SignatureWindowIcons::AoiSignatureMask));
 
       mpAoiSignaturesAction = new QAction(QIcon(pixAoiSignatures), "&Display AOI Signatures and Average "
          "Signature", this);
@@ -277,8 +275,7 @@ bool SignatureWindow::execute(PlugInArgList* pInArgList, PlugInArgList* pOutArgL
 
       // Create the AOI average signature action
       QPixmap pixAoiAverageSig(SignatureWindowIcons::AoiAverageSignatureIcon);
-      QBitmap bmpAoiAverageSigMask(SignatureWindowIcons::AoiAverageSignatureMask);
-      pixAoiAverageSig.setMask(bmpAoiAverageSigMask);
+      pixAoiAverageSig.setMask(QPixmap(SignatureWindowIcons::AoiAverageSignatureMask));
 
       mpAoiAverageSigAction = new QAction(QIcon(pixAoiAverageSig), "&Display AOI Average Signature", this);
       mpAoiAverageSigAction->setAutoRepeat(false);

--- a/Code/SignatureWindow/SignatureWindow.h
+++ b/Code/SignatureWindow/SignatureWindow.h
@@ -1,6 +1,6 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
@@ -10,7 +10,7 @@
 #ifndef SIGNATUREWINDOW_H
 #define SIGNATUREWINDOW_H
 
-#include <QtGui/QAction>
+#include <QtWidgets/QAction>
 
 #include "AttachmentPtr.h"
 #include "DesktopServices.h"

--- a/Code/SignatureWindow/SignatureWindowOptions.cpp
+++ b/Code/SignatureWindow/SignatureWindowOptions.cpp
@@ -1,20 +1,20 @@
 /*
  * The information in this file is
- * Copyright(c) 2010 Ball Aerospace & Technologies Corporation
+ * Copyright(c) 2021 Ball Aerospace & Technologies Corporation
  * and is subject to the terms and conditions of the
  * GNU Lesser General Public License Version 2.1
  * The license text is available from   
  * http://www.gnu.org/licenses/lgpl.html
  */
 
-#include <QtGui/QButtonGroup>
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QGridLayout>
-#include <QtGui/QGroupBox>
-#include <QtGui/QLabel>
-#include <QtGui/QLayout>
-#include <QtGui/QRadioButton>
+#include <QtWidgets/QButtonGroup>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLayout>
+#include <QtWidgets/QRadioButton>
 
 #include "AppVerify.h"
 #include "CustomColorButton.h"


### PR DESCRIPTION
Add SignatureWindow to spectral/Code/CMakeLists.txt and bring SignatureWindow source code up-to-date for Qt5.
This should have been done a year ago.
I've tested this only on Fedora 34, but the Qt5 changes are trivial and similar to what we did last year for the other Spectral plugins. 